### PR TITLE
Add support for multi-entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-preset-es2015": "^6.9.0"
+    "babel-preset-es2015": "^6.9.0",
+    "rollup-plugin-multi-entry": "^2.0.1"
   }
 }

--- a/src/RollupTask.js
+++ b/src/RollupTask.js
@@ -10,6 +10,7 @@ let source;
 let replace;
 let commonjs;
 let nodeResolve;
+let multiEntry;
 
 class RollupTask extends Elixir.Task {
 
@@ -66,6 +67,7 @@ class RollupTask extends Elixir.Task {
         replace = require('rollup-plugin-replace');
         commonjs = require('rollup-plugin-commonjs');
         nodeResolve = require('rollup-plugin-node-resolve');
+        multiEntry = require('rollup-plugin-multi-entry');
     }
 
 
@@ -92,7 +94,8 @@ class RollupTask extends Elixir.Task {
                 replace({
                     'process.env.NODE_ENV': JSON.stringify(Elixir.inProduction)
                 }),
-                buble()
+                buble(),
+                multiEntry()
             ]
         }, this.rollupConfig, this.options))
     }


### PR DESCRIPTION
Playing around with elixir-rollup on Laravel 5.3, and I noticed that there was no support for multi-entry on mix.rollup([]) (when passing in an array it throws a TypeError for <string>).

Documentation in README.md was ambiguous to whether or not you needed to pull in the plugin yourself, or if it came with the wrapper.

Adding it in to package.json and GulpTask to reflect README.md.
