### PR TITLE
Fixed option renames for rollup

### DIFF
--- a/src/RollupTask.js
+++ b/src/RollupTask.js
@@ -99,9 +99,9 @@ class RollupTask extends Elixir.Task {
             extend({
                 entry: this.src.path,
                 cache: cache,
-                sourceMap: true,
+                sourcemap: true,
                 format: 'iife',
-                moduleName: 'LaravelElixirBundle',
+                name: 'LaravelElixirBundle',
                 plugins: plugins
             }, this.rollupConfig, this.options)
         )


### PR DESCRIPTION
I've changed the config so this plugin will work again with the latest rollup as mentioned in #20 