### PR TITLE
Change Rollup task config keys name (Fixes #19)

### DIFF
--- a/src/RollupTask.js
+++ b/src/RollupTask.js
@@ -99,9 +99,9 @@ class RollupTask extends Elixir.Task {
             extend({
                 entry: this.src.path,
                 cache: cache,
-                sourceMap: true,
+                sourcemap: true,
                 format: 'iife',
-                moduleName: 'LaravelElixirBundle',
+                name: 'LaravelElixirBundle',
                 plugins: plugins
             }, this.rollupConfig, this.options)
         )


### PR DESCRIPTION
Rollup recently changed some config keys like sourceMap into sourcemap and moduleName into name.